### PR TITLE
Use staging branch to deploy to /staging

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,73 @@
+# Workflow to deploy main and staging content to GitHub Pages
+name: Deploy main and staging content to GitHub Pages
+
+on:
+  push:
+    branches:
+      - "main"
+      - "staging"
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      # Fetch and prepare main branch content
+      - name: Fetch main branch content into temporary directory
+        run: |
+          echo "Fetching main branch content..."
+          mkdir -p temp_main
+          git clone --branch main --depth 1 https://github.com/${{ github.repository }} temp_main
+          echo "Copying main branch content to deploy directory..."
+          mkdir -p deploy
+          rsync -av --exclude='.git' temp_main/ deploy/
+
+      # Check if staging branch exists before attempting to fetch
+      - name: Check if staging branch exists
+        id: check_staging
+        run: |
+          if git ls-remote --heads https://github.com/${{ github.repository }} staging | grep 'staging'; then
+            echo "staging_exists=true" >> $GITHUB_ENV
+          else
+            echo "staging_exists=false" >> $GITHUB_ENV
+          fi
+
+      # Fetch and prepare staging branch content if it exists
+      - name: Fetch staging branch content into temporary directory
+        if: env.staging_exists == 'true'
+        run: |
+          echo "Fetching staging branch content..."
+          mkdir -p temp_staging
+          git clone --branch staging --depth 1 https://github.com/${{ github.repository }} temp_staging
+          echo "Copying staging branch content to /staging/ directory..."
+          mkdir -p deploy/staging
+          rsync -av --exclude='.git' temp_staging/ deploy/staging/
+
+      - name: Verify Content Structure
+        run: |
+          echo "Final deployment directory structure:"
+          tree deploy || echo "tree command not available"
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: deploy
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
     <!-- Header -->
     <header class="bg-gray-900 text-white p-4 flex justify-between items-center">
         <div class="flex items-center gap-4">
-            <h1 class="text-l"><a href="https://amche.in" class="text-white hover:underline">amche.in</a></h1>
+            <h1 class="text-l"><a href="https://amche.in" class="text-white hover:underline">amche.in > staging</a></h1>
             <a href="/sound/index.html" onclick="navigateToSound(event)" class="text-white hover:text-gray-300"
                 title="Sound Map">
                 <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">


### PR DESCRIPTION
This PR takes a quick stab at #52 – adds a github action to deploy main branch at root, and staging branch at /staging. 

cc @batpad @planemad – was wondering for our specific project (static pages) we can perhaps work with https://amche.in/staging/ (or _staging ) for staging work without needing separate service to host? What do you think?

note: added "staging" in index.html for testing, to be removed.

main version
<img width="423" alt="image" src="https://github.com/user-attachments/assets/60f9656f-18b9-45d6-bc7f-8d37ce802cb4" />

staging version
<img width="501" alt="image" src="https://github.com/user-attachments/assets/4a60cbb2-ecbb-4168-ad85-be7cd1086d6f" />
