### PR TITLE
Use dev branch to deploy to /dev #55

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,77 @@
+# When code is pushed to either main or dev branch:
+# - main branch content gets deployed to the root (amche.in/)
+# - dev branch content gets deployed to /dev/ (amche.in/dev/)
+# Every push triggers deployment of BOTH branches, regardless of which branch received the push.
+# this ensures both environments stay in sync with each deployment.
+name: Deploy main and dev content to amche.in via GitHub Pages
+
+on:
+  push:
+    branches:
+      - "main"
+      - "dev"
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      # Fetch and prepare main branch content
+      - name: Fetch main branch content into temporary directory
+        run: |
+          echo "Fetching main branch content..."
+          mkdir -p temp_main
+          git clone --branch main --depth 1 https://github.com/${{ github.repository }} temp_main
+          echo "Copying main branch content to deploy directory..."
+          mkdir -p deploy
+          rsync -av --exclude='.git' temp_main/ deploy/
+
+      # Check if dev branch exists before attempting to fetch
+      - name: Check if dev branch exists
+        id: check_dev
+        run: |
+          if git ls-remote --heads https://github.com/${{ github.repository }} dev | grep 'dev'; then
+            echo "dev_exists=true" >> $GITHUB_ENV
+          else
+            echo "dev_exists=false" >> $GITHUB_ENV
+          fi
+
+      # Fetch and prepare dev branch content if it exists
+      - name: Fetch dev branch content into temporary directory
+        if: env.dev_exists == 'true'
+        run: |
+          echo "Fetching dev branch content..."
+          mkdir -p temp_dev
+          git clone --branch dev --depth 1 https://github.com/${{ github.repository }} temp_dev
+          echo "Copying dev branch content to /dev/ directory..."
+          mkdir -p deploy/dev
+          rsync -av --exclude='.git' temp_dev/ deploy/dev/
+
+      - name: Verify Content Structure
+        run: |
+          echo "Final deployment directory structure:"
+          tree deploy || echo "tree command not available"
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: deploy
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Use static.yml to deploy main and dev content to amche.in via GitHub… Pages

 When code is pushed to either main or dev branch:
 - main branch content gets deployed to the root (amche.in/)
 - dev branch content gets deployed to /dev/ (amche.in/dev/) Every push triggers deployment of BOTH branches, regardless of which branch received the push. this ensures both environments stay in sync with each deployment.